### PR TITLE
Turn off the progress bar for scaling procedure

### DIFF
--- a/33-seurat.Rmd
+++ b/33-seurat.Rmd
@@ -96,7 +96,8 @@ To mitigate the effect of confounding factors, `Seurat` constructs linear models
 ```{r message=FALSE, warning=FALSE, paged.print=FALSE}
 seuset <- ScaleData(
     object = seuset, 
-    vars.to.regress = c("nUMI")
+    vars.to.regress = c("nUMI"),
+    display.progress = F
 )
 ```
 


### PR DESCRIPTION

## 9.5 [Dealing with confounders](https://hemberg-lab.github.io/scRNA.seq.course/seurat-chapter.html#dealing-with-confounders-1)  
```r
seuset <- ScaleData(
    object = seuset, 
    vars.to.regress = c("nUMI")
)
```
```
## [1] "Regressing out nUMI"
## 
  |                                                                       
  |                                                                 |   0%
  |                                                                       
  |=                                                                |   1%
  |                                                                       
  |=                                                                |   2%
  |                                                                       
  |==                                                               |   2%
  |                                                                       
  |==                                                               |   3%
  |                                                                       
  |==                                                               |   4%
  |                                                                       
  |===                                                              |   4%
  |                                                                       
  |===                                                              |   5%
...
```